### PR TITLE
Combine symmetric tags over body and pubkey fields

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -9,7 +9,30 @@ jobs:
 
     steps:
     - uses: actions/checkout@v1
-    - name: Build
-      run: cargo build --verbose
-    - name: Run tests
-      run: cargo test --verbose
+    - uses: actions-rs/toolchain@v1
+      with:
+        toolchain: nightly
+        override: true
+        components: rustfmt, clippy
+
+    - name: Configure cargo cache
+      uses: actions/cache@v1
+      with:
+        key: cargo-check
+        path: ${{ env.HOME }}/.cargo"
+
+    - name: Configure target cache
+      uses: actions/cache@v1
+      with:
+        key: target-check
+        path: ./target
+
+    - name: Run cargo build
+      uses: actions-rs/cargo@v1
+      with:
+        command: build
+
+    - name: Run cargo test
+      uses: actions-rs/cargo@v1
+      with:
+        command: test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,0 @@
-language: rust
-notifications:
-  email:
-    on_success: never
-    on_failure: never

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ edition = "2018"
 
 [features]
 std = [ "managed/std", "bytes/std", "base64/std", "byteorder/std", "sha2/std", "chrono/std", "strum", "strum_macros", "thiserror" ]
-alloc = [ "base64/alloc", "chrono/alloc" ]
+alloc = [ "base64/alloc", "chrono/alloc", "pretty-hex/alloc" ]
 default = [ "std", "serde" ]
 
 
@@ -29,6 +29,7 @@ rand_core = { version = "0.5.1", default_features = false }
 thiserror = { version = "1.0.11", default_features = false, optional = true }
 defmt = { version = "0.2.1", optional = true }
 derivative = "2.2.0"
+pretty-hex = { version = "0.2.1", default_features = false }
 
 [dependencies.managed]
 version = "0.7.1"
@@ -75,3 +76,6 @@ version = "1.0"
 
 [patch.crates-io]
 sodiumoxide = { git = "https://github.com/sodiumoxide/sodiumoxide.git" }
+
+[dev-dependencies]
+simplelog = "0.10.2"

--- a/src/base/body.rs
+++ b/src/base/body.rs
@@ -47,6 +47,9 @@ pub struct Base {
     /// This is automatically included / extracted to simplify higher level parsing
     pub(crate) peer_id: Option<Id>,
 
+    /// Object tag (if encrypted)
+    pub(crate) tag: Option<Vec<u8>>,
+
     /// Object signature
     pub(crate) signature: Option<Signature>,
 
@@ -222,6 +225,7 @@ impl Base {
             public_key: options.public_key,
             peer_id: options.peer_id,
             signature: options.signature,
+            tag: None,
             verified: false,
             raw: options.raw,
         }
@@ -404,6 +408,8 @@ mod tests {
 
         let header = Header {
             kind: PageKind::Generic.into(),
+            application_id: 10,
+            index: 12,
             ..Default::default()
         };
         let data = vec![1, 2, 3, 4, 5, 6, 7];

--- a/src/base/mod.rs
+++ b/src/base/mod.rs
@@ -66,6 +66,11 @@ pub trait Encode {
     /// Encode method writes object data to the provided writer
     fn encode(&self, buff: &mut [u8]) -> Result<usize, Self::Error>;
 
+    /// Encode len fetches expected encoded length for an object
+    fn encode_len(&self) -> Result<usize, Self::Error> {
+        todo!()
+    }
+
     /// Encode a iterator of encodable objects
     fn encode_iter<'a, V: Iterator<Item = &'a Self>>(
         vals: V,

--- a/src/net/response.rs
+++ b/src/net/response.rs
@@ -285,7 +285,7 @@ impl Into<Base> for Response {
                 }
 
                 // Encode options list to body
-                let n = Options::encode_vec(&options, &mut buff[ID_LEN..]).unwrap();
+                let n = Options::encode_iter(&options, &mut buff[ID_LEN..]).unwrap();
 
                 body = buff[..ID_LEN + n].to_vec();
             }

--- a/src/service/mod.rs
+++ b/src/service/mod.rs
@@ -7,6 +7,7 @@ use crate::base::{Body, PrivateOptions};
 use crate::crypto;
 use crate::error::Error;
 use crate::options::Options;
+use crate::prelude::Parse;
 use crate::types::*;
 
 #[cfg(feature = "alloc")]
@@ -171,6 +172,8 @@ mod test {
 
     #[test]
     fn test_service() {
+        let _ = simplelog::SimpleLogger::init(simplelog::LevelFilter::Debug, simplelog::Config::default());
+
         let socket = SocketAddrV4::new(Ipv4Addr::new(127, 0, 0, 1), 8080);
 
         println!("Creating new service");

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -58,6 +58,8 @@ pub const SECRET_KEY_LEN: usize = 32;
 /// Secret key type
 pub type SecretKey = Array32;
 
+pub const SECRET_KEY_TAG_LEN: usize = 40;
+
 pub const HASH_LEN: usize = 32;
 
 pub type CryptoHash = Array32;


### PR DESCRIPTION
Saves 40 bytes where both body and private options fields are used.